### PR TITLE
Disable ansic.lua on windows main/dev

### DIFF
--- a/lua/gangbox/modules/ansic.lua
+++ b/lua/gangbox/modules/ansic.lua
@@ -1,3 +1,5 @@
+-- Don't add ANSI colouring on dev/main branch on windows as it breaks colour output
+if system.IsWindows() and BRANCH != "x86-64" then return end
 -- MsgC but with Colors converted to ANSI codes for server console output
 
 local _MsgC = rawget( _G, "MsgC" )


### PR DESCRIPTION
Fixes terminal colouring getting break on windows outside x64 branch or linux
This is useful only for SRCDS instances ran in windows